### PR TITLE
Fix elements exceeding node size for unrolled lists

### DIFF
--- a/src/unrolled.rs
+++ b/src/unrolled.rs
@@ -509,8 +509,8 @@ impl<T: Clone, P: PointerFamily, const N: u32, const G: u32> UnrolledList<T, P, 
     // Every node must have either CAPACITY elements, or be marked as full
     // Debateable whether I want them marked as full
     #[cfg(test)]
-    pub fn assert_invariants(&self) -> bool {
-        self.node_iter().all(Self::does_node_satisfy_invariant)
+    pub fn assert_invariants(&self) {
+        assert!(self.node_iter().all(Self::does_node_satisfy_invariant))
     }
 
     pub fn get(&self, mut index: usize) -> Option<&T> {

--- a/src/unrolled.rs
+++ b/src/unrolled.rs
@@ -1175,6 +1175,9 @@ impl<T: Clone, P: PointerFamily, const N: u32, const G: u32> FromIterator<Unroll
                     // Swap the locations now after we've done the update
                     std::mem::swap(&mut left_inner.elements, &mut right_inner.elements);
 
+                    // Update this node to use correct capacity
+                    std::mem::swap(&mut left_inner.size, &mut right_inner.size);
+
                     // Adjust the indices accordingly
                     left_inner.index = left_inner.elements.len() as u32;
                     right_inner.index = 0;

--- a/src/unrolled.rs
+++ b/src/unrolled.rs
@@ -1294,6 +1294,7 @@ mod iterator_tests {
     const CAPACITY: usize = 256;
 
     type RcList<T> = UnrolledList<T, RcPointer, 256, 1>;
+    type SmallRcList<T> = UnrolledList<T, RcPointer, 4, 2>;
 
     #[test]
     fn check_size() {
@@ -1359,6 +1360,26 @@ mod iterator_tests {
         // 300 should be at 300
         assert_eq!(*left.get(300).unwrap(), 300);
         left.assert_list_invariants();
+    }
+
+    #[test]
+    fn empty_node_appending_coalescing_works() {
+        // 0/4: []
+        let left: SmallRcList<i32> = SmallRcList::new();
+
+        // 4/4: [2, 3, 4, 5]
+        // 2/8: [0, 1]
+        let right: SmallRcList<_> = (0..6).collect::<SmallRcList<_>>().reverse();
+
+        assert_eq!(right.node_iter().count(), 2);
+
+        // 6/8: [0, 1, 2, 3, 4, 5]
+        let left = left.append(right);
+
+        assert_eq!(left.node_iter().count(), 1);
+        assert!(!left.is_empty());
+        assert_eq!(*left.get(5).unwrap(), 0);
+        left.assert_invariants();
     }
 
     #[test]


### PR DESCRIPTION
On coalesce, the left and right nodes' locations and pointers are swapped, but not size, meaning that a node could have 6 elements but have size 4.

If you append this resulting node to an empty list, they don't coalesce and an empty node would remain as the head, while still linking to the other node, causing what you see below:

## Before

```scheme
(define (foo x)
  (append '() (reverse (range 0 x))))

;; 5 to 8 fail
(foo 4) ; => '(3 2 1 0)
(foo 5) ; => '()
(foo 6) ; => '()
(foo 7) ; => '()
(foo 8) ; => '()
(foo 9) ; => '(8 7 6 5 4 3 2 1 0)

;; contradicting length and empty?
(length (foo 6)) ; => 6
(empty? (foo 6)) ; => #true
```

```rust
type SmallRcList<T> = UnrolledList<T, RcPointer, 4, 2>;
let left: SmallRcList<i32> = SmallRcList::new();
let right: SmallRcList<_> = (0..6).collect::<SmallRcList<_>>().reverse();
let left = left.append(right);

left.node_iter().for_each(|node| {
    println!("{}/{}: {:?}", node.index(), node.size(), node.elements());
});

// Output:
// 0/4: []
// 6/4: [0, 1, 2, 3, 4, 5]
````

## After
After adding the size swap + test

```scheme
(foo 4) ; => '(3 2 1 0)
(foo 5) ; => '(4 3 2 1 0)
(foo 6) ; => '(5 4 3 2 1 0)
(foo 7) ; => '(6 5 4 3 2 1 0)
(foo 8) ; => '(7 6 5 4 3 2 1 0)
(foo 9) ; => '(8 7 6 5 4 3 2 1 0)

(length (foo 6)) ; => 6
(empty? (foo 6)) ; => #false
```

```rust
// same rust code

// Output:
// 6/8: [0, 1, 2, 3, 4, 5]
````

## Notes
Also, seems like `asserts_invariants()` didn't call `assert!`, when I added it, more errors appeared. All seem fixed after my change.

```
failures:
    unrolled::iterator_tests::empty_node_appending_coalescing_works
    unrolled::proptests::vlist::append_non_mut_resulting_length_equivalent
    unrolled::proptests::vlist::append_resulting_length_equivalent
    unrolled::proptests::vlist::append_zero_then_popfront
    unrolled::proptests::vlist::operations_in_order_match
    unrolled::proptests::vlist::test_case_with_pop_front
    unrolled::proptests::vlist::test_case_with_reverse
    unrolled::proptests::vlist_growth_rate_4::append_non_mut_resulting_length_equivalent
    unrolled::proptests::vlist_growth_rate_4::append_resulting_length_equivalent
    unrolled::proptests::vlist_growth_rate_4::cdr_to_append
    unrolled::proptests::vlist_growth_rate_4::larger_test_case
    unrolled::proptests::vlist_growth_rate_4::operations_in_order_match
    unrolled::proptests::vlist_growth_rate_4::test_case_with_pop_front
    unrolled::proptests::vlist_growth_rate_4::test_case_with_reverse

test result: FAILED. 210 passed; 14 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.25s
```

```
test result: ok. 224 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.51s
```
